### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @ministryofjustice/analytics-hq


### PR DESCRIPTION
When PRs are created, instead of asking the wider team to all review, let's manually invite particular people