### PR TITLE
Add weekly rshiny image rebuild

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ name: Build & Test
     branches: [main]
     tags: ["*"]
   schedule:
-    - cron: "0 4 0 0 6"
+    - cron: '0 4 0 0 6'
 jobs:
   yamllint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
 
   docker:
     if: ${{ github.repository }} == 'analytics-platform-rshiny'
-    runs-on: [self-hosted, management-ecr]
+    runs-on: ubuntu-20.04
     env:
       REPOSITORY: rshiny
       ECR_REPOSITORY: rshiny

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,8 @@ name: Build & Test
     branches: [main]
     tags: ["*"]
   schedule:
-    - cron: '0 0 4 * 6'
+    - cron: '0 0 * * SAT'
+    
 jobs:
   yamllint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,8 @@ name: Build & Test
   push:
     branches: [main]
     tags: ["*"]
-
+  schedule:
+    - cron: "0 4 0 0 6"
 jobs:
   yamllint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ name: Build & Test
     branches: [main]
     tags: ["*"]
   schedule:
-    - cron: '0 4 0 0 6'
+    - cron: '0 0 4 * 6'
 jobs:
   yamllint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
 
   docker:
     if: ${{ github.repository }} == 'analytics-platform-rshiny'
-    runs-on: [self-hosted, ecr]
+    runs-on: [self-hosted, management-ecr]
     env:
       REPOSITORY: rshiny
       ECR_REPOSITORY: rshiny

--- a/README.md
+++ b/README.md
@@ -29,3 +29,16 @@ Each shiny app has its own repository with `Dockerfile` based on [`moj-analytica
 This docker image is [used as base image in the `moj-analytical-services/rshiny-template` repository (`conda` branch)](https://github.com/moj-analytical-services/rshiny-template/blob/conda/Dockerfile#L1).
 
 Another significant difference of the `conda` branch is that it also [uses `analytics-platform-shiny-server`](https://github.com/moj-analytical-services/rshiny-template/blob/conda/Dockerfile#L17) instead of official shiny server - main reason for this was to be able to use R environment installed with conda (or any R environment in your `PATH`).
+
+# Versioning
+
+This repository was historically rebuilt relatively infrequently. We have now added scheduled 
+updates that occur weekly, to keep the base image up to date. This alters the semver scheme from 
+4.0.0 onwards, meaning that:
+
+* CI generates patches
+* non-breaking changes get a minor version bump
+* Breaking changes get a major version bump
+
+This is still not ideal but should be better than what came before while we work out a proper 
+build and release management approach.

--- a/README.md
+++ b/README.md
@@ -32,13 +32,10 @@ Another significant difference of the `conda` branch is that it also [uses `anal
 
 # Versioning
 
-This repository was historically rebuilt relatively infrequently. We have now added scheduled 
-updates that occur weekly, to keep the base image up to date. This alters the semver scheme from 
-4.0.0 onwards, meaning that:
+This repository was historically rebuilt relatively infrequently. We have now added scheduled updates that occur weekly, to keep the base image up to date. This alters the semver scheme from 4.0.0 onwards, meaning that:
 
 * CI generates patches
 * non-breaking changes get a minor version bump
 * Breaking changes get a major version bump
 
-This is still not ideal but should be better than what came before while we work out a proper 
-build and release management approach.
+This is still not ideal but should be better than what came before while we work out a proper build and release management approach.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This docker image is [used as base image in the `moj-analytical-services/rshiny-
 
 Another significant difference of the `conda` branch is that it also [uses `analytics-platform-shiny-server`](https://github.com/moj-analytical-services/rshiny-template/blob/conda/Dockerfile#L17) instead of official shiny server - main reason for this was to be able to use R environment installed with conda (or any R environment in your `PATH`).
 
-# Versioning
+## Versioning
 
 This repository was historically rebuilt relatively infrequently. We have now added scheduled updates that occur weekly, to keep the base image up to date. This alters the semver scheme from 4.0.0 onwards, meaning that:
 


### PR DESCRIPTION
Problem:

* There are only three tags in this repository.
* Images are generally ancient and riddled with vulnerabilities
* Images which are not ancient are tagged `local` because they have been built manually using `make build` and `make push` from someone's laptop. This gives no indication at all as to the 'freshness' of the image.

This PR adds a weekly build of the rshiny image: there is an `apt-get update && apt-get upgrade` in the container which should address a range of the security issues that arise from old, unpatched base images. *This is not intended to be a permanent solution*: this relates to [ANPL-1295](https://dsdmoj.atlassian.net/browse/ANPL-1295) which is intended to address vulnerabilities in containers. We should at least try to provide a secure baseline for people to build their containers from.

[ANPL-1295]: https://dsdmoj.atlassian.net/browse/ANPL-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ