### PR TITLE
Fixing tags for build workflow running on a branch to remove slashes.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,5 +89,5 @@ jobs:
           ECR_REPOSITORY: "rshiny"
           IMAGE_TAG: "r${{ matrix.r }}-shiny${{ matrix.shinyserver }}-${{ github.head_ref }}"
         run: |
-          docker build --build-arg r=${{ matrix.r }} --build-arg shinyserver=${{ matrix.shinyserver }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker build --build-arg r=${{ matrix.r }} --build-arg shinyserver=${{ matrix.shinyserver }} -t $ECR_REGISTRY/$ECR_REPOSITORY:${IMAGE_TAG//\//""} .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${IMAGE_TAG//\//""}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+**/**.vscode


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/ANPL-1492

Fixing the dev workflow because it was failing when the branch name has a slash in it.

Solution: remove all slashes from the IMAGE_TAG var before using it as a tag.